### PR TITLE
gh

### DIFF
--- a/programs/gh.nix
+++ b/programs/gh.nix
@@ -1,0 +1,9 @@
+{ ... }:
+{
+  programs.gh = {
+    enable = true;
+    settings = {
+      git_protocol = "ssh";
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Add GitHub CLI via `programs.gh` Home Manager module
- Configure `git_protocol = "ssh"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)