### PR TITLE
Add direnv flake dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,19 @@
   outputs =
     { nixpkgs, home-manager, ... }:
     let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSystem =
+        f:
+        builtins.listToAttrs (
+          map (system: {
+            name = system;
+            value = f system;
+          }) systems
+        );
       mkConfig =
         system:
         home-manager.lib.homeManagerConfiguration {
@@ -25,5 +38,8 @@
         "otto@x86_64-linux" = mkConfig "x86_64-linux";
         "otto@aarch64-linux" = mkConfig "aarch64-linux";
       };
+      devShells = forEachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.mkShell { };
+      });
     };
 }

--- a/programs/direnv.nix
+++ b/programs/direnv.nix
@@ -1,5 +1,8 @@
 _:
 
 {
-  programs.direnv.enable = true;
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+  };
 }


### PR DESCRIPTION
## Summary

- Enable `nix-direnv` in `programs/direnv.nix` for fast, cached `use flake` support
- Add `devShells.default` output to `flake.nix` for all three supported systems, using a shared `forEachSystem` helper
- Add `.envrc` with `use flake` to activate the dev shell on `cd`

## Test plan

- [x] `direnv allow` in the repo root loads without errors
- [x] Re-entering the directory after the first load is instant (nix-direnv cache hit)
- [x] `nix flake check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)