### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@v21
 
+      - name: Install lint tools
+        run: nix profile install nixpkgs#nixfmt nixpkgs#statix nixpkgs#deadnix nixpkgs#shellcheck
+
       - uses: j178/prek-action@v2.0.0
 
   build:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with two parallel jobs: `lint` and `build`
- `lint` runs all prek hooks via `j178/prek-action@v2.0.0`
- `build` builds the `x86_64-linux` home configuration using `nix build`
- Both jobs use `DeterminateSystems/nix-installer-action@v21` to match production

## Test plan

- [x] Confirm both jobs appear and run on this PR
- [x] Confirm `lint` passes (prek hooks: nixfmt, statix, deadnix, shellcheck)
- [x] Confirm `build` succeeds for `otto@x86_64-linux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)