### PR TITLE
Only run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary

- Removes the `push` trigger from the CI workflow
- CI now runs only on `pull_request` events

## Why

After a PR is merged, the push to `main` was triggering CI again. The `lint` job was failing because `no-commit-to-branch` sees `main` and exits non-zero. Since all changes go through PRs (enforced by prek), the push trigger is redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)