### PR TITLE
feat: switch nix hooks to auto-fix mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,9 @@ These run tools that are installed via home-manager packages:
 
 | Hook | Tool | What it checks |
 |------|------|----------------|
-| `nixfmt` | `nixfmt --check` | Nix files are correctly formatted |
-| `statix` | `statix check` | Nix anti-patterns and lints |
-| `deadnix` | `deadnix --fail` | Unused bindings in Nix files |
+| `nixfmt` | `nixfmt` | Auto-formats Nix files in place |
+| `statix` | `statix fix` | Auto-fixes Nix anti-patterns in place |
+| `deadnix` | `deadnix --edit` | Auto-removes unused Nix bindings in place |
 | `shellcheck` | `shellcheck` | Shell script correctness |
 
 `statix` and `deadnix` are installed by `programs/hx/nix.nix`.

--- a/prek.toml
+++ b/prek.toml
@@ -13,8 +13,8 @@ hooks = [
 [[repos]]
 repo = "local"
 hooks = [
-  {id = "nixfmt",    name = "nixfmt",    entry = "nixfmt --check", language = "system", files = "\\.nix$"},
-  {id = "statix",    name = "statix",    entry = "statix check",   language = "system", pass_filenames = false},
-  {id = "deadnix",   name = "deadnix",   entry = "deadnix --fail", language = "system", files = "\\.nix$"},
+  {id = "nixfmt",    name = "nixfmt",    entry = "nixfmt",        language = "system", files = "\\.nix$"},
+  {id = "statix",    name = "statix",    entry = "statix fix",    language = "system", pass_filenames = false},
+  {id = "deadnix",   name = "deadnix",   entry = "deadnix --edit", language = "system", files = "\\.nix$"},
   {id = "shellcheck", name = "shellcheck", entry = "shellcheck",   language = "system", files = "\\.sh$"},
 ]


### PR DESCRIPTION
## Summary

- `nixfmt --check` → `nixfmt`: formats `.nix` files in place
- `statix check` → `statix fix`: rewrites Nix anti-patterns in place
- `deadnix --fail` → `deadnix --edit`: removes unused bindings in place
- `shellcheck` unchanged — linter only, no auto-fix available
- Updated `CLAUDE.md` to reflect the new commands

On a hook failure the tools now modify files on disk. Re-staging the changes and committing again picks up the fixes — same behaviour as the builtin `trailing-whitespace` hook.

## Test plan

- [x] Commit a poorly-formatted `.nix` file and confirm the hook fixes it, blocks the commit, and the re-commit succeeds
- [x] Confirm `shellcheck` still blocks on shell script issues without modifying files

🤖 Generated with [Claude Code](https://claude.com/claude-code)