### PR TITLE
Add news command alongside switch for all platforms

### DIFF
--- a/programs/shell.nix
+++ b/programs/shell.nix
@@ -11,6 +11,13 @@ let
     '';
   };
 
+  newsDarwinAarch64 = pkgs.writeShellApplication {
+    name = "news";
+    text = ''
+      home-manager news --flake github:ojhermann/home-manager#otto@aarch64-darwin
+    '';
+  };
+
   switchLinuxX86_64 = pkgs.writeShellApplication {
     name = "switch";
     text = ''
@@ -18,10 +25,24 @@ let
     '';
   };
 
+  newsLinuxX86_64 = pkgs.writeShellApplication {
+    name = "news";
+    text = ''
+      home-manager news --flake github:ojhermann/home-manager#otto@x86_64-linux
+    '';
+  };
+
   switchLinuxAarch64 = pkgs.writeShellApplication {
     name = "switch";
     text = ''
       home-manager switch --flake github:ojhermann/home-manager#otto@aarch64-linux --refresh
+    '';
+  };
+
+  newsLinuxAarch64 = pkgs.writeShellApplication {
+    name = "news";
+    text = ''
+      home-manager news --flake github:ojhermann/home-manager#otto@aarch64-linux
     '';
   };
 
@@ -59,15 +80,18 @@ in
     newBash
     watchDir
   ]
-  ++ lib.optional (
-    pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64
-  ) switchDarwinAarch64
-  ++ lib.optional (
-    pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86_64
-  ) switchLinuxX86_64
-  ++ lib.optional (
-    pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isAarch64
-  ) switchLinuxAarch64;
+  ++ lib.optionals (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) [
+    switchDarwinAarch64
+    newsDarwinAarch64
+  ]
+  ++ lib.optionals (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86_64) [
+    switchLinuxX86_64
+    newsLinuxX86_64
+  ]
+  ++ lib.optionals (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isAarch64) [
+    switchLinuxAarch64
+    newsLinuxAarch64
+  ];
 
   home.activation.sudoByTouch = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
     lib.hm.dag.entryAfter [ "writeBoundary" ] (builtins.readFile ./shell/scripts/sudo-by-touch.sh)


### PR DESCRIPTION
## Summary

- Adds a `news` command for each platform, mirroring the `switch` command
- Fixes `home-manager news` failing with "No configuration file found" by passing `--flake` with the appropriate system attribute
- Switches from `lib.optional` to `lib.optionals` to cleanly install both `switch` and `news` per platform

## Usage

```bash
news   # home-manager news --flake github:ojhermann/home-manager#otto@<system>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)