### PR TITLE
Add magic-nix-cache-action to CI for faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@v21
 
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+
       - name: Install lint tools
         run: nix profile install nixpkgs#nixfmt nixpkgs#statix nixpkgs#deadnix nixpkgs#shellcheck
 
@@ -22,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@v21
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
 
       - name: Build x86_64-linux configuration
         run: nix build .#homeConfigurations."otto@x86_64-linux".activationPackage --no-link


### PR DESCRIPTION
## Summary

- Adds `DeterminateSystems/magic-nix-cache-action@v13` to both the `lint` and `build` jobs
- Caches Nix store paths in GitHub Actions cache, speeding up repeated `nix profile install` and `nix build` calls across runs
- No external accounts or additional cost — uses GitHub's built-in cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)