### PR TITLE
feat: add working environment and conventions to global CLAUDE.md

### DIFF
--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -1,3 +1,15 @@
 # Global Claude Code guidance
 
 <!-- Preferences, conventions, and instructions that apply across all projects. -->
+
+## Git hooks
+
+Each repo should include a `prek.toml` to manage pre-commit hooks via [prek](https://github.com/j178/prek). The `ojhermann/home-manager` repo is a good reference for hook configuration.
+
+## Configuration management
+
+Config, dotfiles, and tooling are managed via Home Manager in the `ojhermann/home-manager` repo. Barring exceptional circumstances, changes should be made there rather than editing files directly.
+
+## Working environment
+
+Otto is almost always working inside Zellij. Prefer Zellij-native suggestions (pane splits, tabs, layouts) over generic terminal advice.


### PR DESCRIPTION
## Summary

- Documents that config/dotfiles/tooling should be managed via Home Manager in this repo
- Adds convention that each repo should include a `prek.toml` for pre-commit hooks, with this repo as the reference
- Notes that Otto typically works inside Zellij, so Zellij-native suggestions are preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)