### PR TITLE
feat: add post-merge branch cleanup to git workflow guidance

### DIFF
--- a/programs/claude/CLAUDE.md
+++ b/programs/claude/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Git workflow
 
-Unless instructed otherwise, all changes must be committed on a branch other than `main` and merged via a PR. Prefer small, focused PRs over larger ones.
+Unless instructed otherwise, all changes must be committed on a branch other than `main` and merged via a PR. Prefer small, focused PRs over larger ones. After merging a PR, return to `main` and delete the local branch that was just merged.
 
 ## Git hooks
 


### PR DESCRIPTION
## Summary

- After merging a PR, return to `main` and delete the local branch that was just merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)