### PR TITLE
feat: add pre-merge switch reminder to workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,10 @@ from the repo root to ensure the lock file is current before the PR is opened.
 
 ## Workflow
 
+### Before merging a PR
+
+Run `switch` locally to verify the config applies cleanly before merging.
+
 ### Local development / testing
 
 ```bash


### PR DESCRIPTION
## Summary

- Documents that `switch` should be run locally to verify the config applies cleanly before merging a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)