### PR TITLE
feat: auto-allow direnv for repos under ~/Documents

### DIFF
--- a/programs/direnv.nix
+++ b/programs/direnv.nix
@@ -4,5 +4,10 @@ _:
   programs.direnv = {
     enable = true;
     nix-direnv.enable = true;
+    config = {
+      whitelist = {
+        prefix = [ "/Users/otto/Documents" ];
+      };
+    };
   };
 }


### PR DESCRIPTION
## Summary

- Adds a `whitelist.prefix` to the direnv config so `.envrc` files under `/Users/otto/Documents` are trusted automatically, without needing `direnv allow` per repo
- Directories outside that path remain blocked as a security measure

🤖 Generated with [Claude Code](https://claude.com/claude-code)