### PR TITLE
feat: add terraform-docs to home-manager

### DIFF
--- a/programs/terraform-docs.nix
+++ b/programs/terraform-docs.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.terraform-docs
+  ];
+}


### PR DESCRIPTION
Closes #23

## Summary

- Adds `pkgs.terraform-docs` (v0.21.0) as a home-manager package
- Follows the same pattern as `opentofu.nix` and other standalone tool packages

## Test plan

- [ ] Run `switch` and verify `terraform-docs --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)