### PR TITLE
feat: add tflint to home-manager

### DIFF
--- a/programs/tflint.nix
+++ b/programs/tflint.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.tflint
+  ];
+}


### PR DESCRIPTION
Closes #24

## Summary

- Adds `pkgs.tflint` (v0.61.0) as a home-manager package
- Follows the same pattern as `opentofu.nix` and other standalone tool packages

## Test plan

- [ ] Run `switch` and verify `tflint --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)