### PR TITLE
feat: add TLA+ support with Helix formatter

### DIFF
--- a/programs/hx/tlaplus.nix
+++ b/programs/hx/tlaplus.nix
@@ -1,0 +1,10 @@
+_:
+
+{
+  programs.helix.languages.language = [
+    {
+      name = "tlaplus";
+      auto-format = true;
+    }
+  ];
+}

--- a/programs/tlaplus.nix
+++ b/programs/tlaplus.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.tlaplus18
+    pkgs.tlafmt
+  ];
+}


### PR DESCRIPTION
Closes #19 (partial — core tooling and formatter; LSP tracked separately)

## Summary

- Adds `pkgs.tlaplus18` (v1.8.0) — TLC model checker and core TLA+ tools
- Adds `pkgs.tlafmt` (v0.4.1) — TLA+ formatter
- Enables `auto-format = true` for the `tlaplus` language in Helix

## Notes

Helix already has `tlafmt` configured as the default TLA+ formatter and the tree-sitter parser bundled — this just puts `tlafmt` on PATH and turns on auto-format on save. No LSP is available in nixpkgs; that will be addressed in a follow-up PR with a custom derivation.

## Test plan

- [ ] Run `switch` and verify `tlaplus` and `tlafmt` are on PATH
- [ ] Open a `.tla` file in Helix and verify auto-format on save works

🤖 Generated with [Claude Code](https://claude.com/claude-code)