### PR TITLE
fix: skip formae on x86_64-linux (no binary available)

### DIFF
--- a/packages/formae.nix
+++ b/packages/formae.nix
@@ -14,11 +14,6 @@ let
       arch = "arm64";
       hash = "sha256-3240F6ujtvGSHVju/IxRdHjtGtJ7+s5S9Hgi70E5Sh0=";
     };
-    "x86_64-linux" = {
-      os = "linux";
-      arch = "x86-64";
-      hash = "sha256-7NRvtpC1qcbLJ4q6lpKTFNG8Ekf2nr1vPRNwON47o2s=";
-    };
   };
 
   platform = platforms.${pkgs.stdenv.hostPlatform.system};
@@ -51,7 +46,6 @@ pkgs.stdenv.mkDerivation {
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"
-      "x86_64-linux"
     ];
   };
 }

--- a/programs/formae.nix
+++ b/programs/formae.nix
@@ -1,9 +1,12 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
   formae = import ../packages/formae.nix { inherit pkgs; };
+  supported =
+    pkgs.stdenv.hostPlatform.system == "aarch64-darwin"
+    || pkgs.stdenv.hostPlatform.system == "aarch64-linux";
 in
-{
+lib.mkIf supported {
   home.packages = [
     formae
   ];


### PR DESCRIPTION
## Summary

- `formae@0.82.3_linux-x86-64.tgz` returns HTTP 404 — upstream only publishes binaries for `aarch64-darwin` and `aarch64-linux`
- Removes `x86_64-linux` from `packages/formae.nix` platform map and `meta.platforms`
- Guards the install in `programs/formae.nix` with `lib.mkIf` so formae is only included on supported platforms

## Test plan

- [x] CI x86_64-linux build passes (no longer attempts to fetch the missing binary)
- [x] CI aarch64-linux and aarch64-darwin builds continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)