### PR TITLE
feat: add gitleaks to home-manager

### DIFF
--- a/programs/gitleaks.nix
+++ b/programs/gitleaks.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.gitleaks ];
+}


### PR DESCRIPTION
## Summary
- Adds `gitleaks` (v8.30.1) via a new `programs/gitleaks.nix` module
- Verified working locally with `home-manager switch`

## Test plan
- [x] `home-manager switch` applied cleanly
- [x] `gitleaks version` returns `8.30.1`
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)