### PR TITLE
feat: add ct alias for tree (#70)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775683737,
-        "narHash": "sha256-oBYyowo6yfgb95Z78s3uTnAd9KkpJpwzjJbfnpLaM2Y=",
+        "lastModified": 1775781825,
+        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7ba4ee4228ed36123c7cb75d50524b43514ef992",
+        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
         "type": "github"
       },
       "original": {

--- a/packages/claude-code.nix
+++ b/packages/claude-code.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.97";
+  version = "2.1.98";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-J92ILqBJmXyAueUPZ+HYZY0ls3OfN2EAhFyQHTOQF5A=";
+    hash = "sha256-9mziiXKmfYXB5dDpw+M5K9fDb3bsJcO/l0r3hKK9VZ0=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/programs/shell.nix
+++ b/programs/shell.nix
@@ -83,6 +83,7 @@ let
   };
 
   commonAliases = {
+    ct = "tree -aC --gitignore -I \".terraform|.git\"";
     date = "date +'%Y-%m-%d %H:%M:%S'";
     grep = "grep -i --color=auto";
     gs = "git status -sb";
@@ -126,7 +127,9 @@ in
       ignoreDups = true;
     };
     shellAliases = commonAliases;
-    initContent = builtins.readFile ./shell/scripts/zsh-init.sh;
+    initContent = (builtins.readFile ./shell/scripts/zsh-init.sh) + ''
+      compdef ct=tree
+    '';
   };
 
   programs.bash = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {


### PR DESCRIPTION
## Summary

- Adds `ct = tree -aC --gitignore -I ".terraform|.git"` to `commonAliases` in `shell.nix`
- Appends `compdef ct=tree` to zsh `initContent` so tab completion delegates to `tree`'s completions

Closes #70

## Test plan

- [x] Run `switch` locally and verify `ct` works in a new shell
- [x] Confirm `ct <tab>` completes using tree's completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)