### PR TITLE
feat: manage Claude Code static config via home-manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
         "type": "github"
       },
       "original": {

--- a/packages/claude-code.nix
+++ b/packages/claude-code.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.98";
+  version = "2.1.100";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-9mziiXKmfYXB5dDpw+M5K9fDb3bsJcO/l0r3hKK9VZ0=";
+    hash = "sha256-7/Rhk1z3Us2vOYGa85lkVIzzqdQFmfmAxrT39a7D27Y=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/programs/claude-code.nix
+++ b/programs/claude-code.nix
@@ -17,5 +17,7 @@ in
   home.packages = [ claudeCode ];
 
   home.file.".claude/CLAUDE.md".source = ./claude/CLAUDE.md;
+  home.file.".claude/keybindings.json".source = ./claude/keybindings.json;
   home.file.".claude/settings.json".source = ./claude/settings.json;
+  home.file.".claude/commands/pre-pr.md".source = ./claude/commands/pre-pr.md;
 }

--- a/programs/claude/commands/pre-pr.md
+++ b/programs/claude/commands/pre-pr.md
@@ -1,0 +1,50 @@
+Run a pre-PR checklist for the current repository, then open a PR if all checks pass.
+
+## Checks
+
+Run each check in order. Collect all warnings before deciding whether to proceed.
+
+### 1. Branch
+
+Confirm the current branch is not `main`. If it is, warn:
+
+```
+WARNING: You are on `main`. PRs must be opened from a feature branch.
+```
+
+### 2. Commit log
+
+Run `git log --oneline main..HEAD` and display the output. This is informational — no warning, but the user must be able to review it.
+
+### 3. Uncommitted changes
+
+Run `git status --short`. If there is any output, warn:
+
+```
+WARNING: You have uncommitted or unstaged changes.
+```
+
+### 4. Merge conflicts
+
+Search tracked files for conflict markers (`<<<<<<<`). If any are found, warn:
+
+```
+WARNING: Merge conflict markers found in: <file list>
+```
+
+### 5. Prek (if applicable)
+
+If `prek.toml` exists in the repo root:
+
+- Run `prek run -a`
+- If any files were modified by prek, stage them and commit with message: `chore: apply prek auto-fixes`
+- If prek exits non-zero and no files were auto-fixed (or still exits non-zero after committing fixes), warn:
+
+```
+WARNING: prek reported issues that require manual fixes.
+```
+
+## After checks
+
+- **No warnings**: run `gh pr create`.
+- **Any warnings**: display a summary of all warnings and stop. Do not open the PR.

--- a/programs/claude/keybindings.json
+++ b/programs/claude/keybindings.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": [
+    {
+      "context": "Chat",
+      "bindings": {
+        "shift+enter": "chat:newline"
+      }
+    }
+  ]
+}

--- a/programs/claude/settings.json
+++ b/programs/claude/settings.json
@@ -1,1 +1,21 @@
-{}
+{
+  "permissions": {
+    "allow": [
+      "Bash(aws configure:*)",
+      "Bash(aws ec2:*)",
+      "Bash(curl *)",
+      "Bash(gh *)",
+      "Bash(git *)",
+      "Bash(home-manager *)",
+      "Bash(mise *)",
+      "Bash(nix *)",
+      "Bash(prek *)",
+      "Bash(python *)",
+      "Bash(tofu *)",
+      "Bash(uv *)"
+    ],
+    "deny": [
+      "Bash(tofu apply*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `keybindings.json` and `commands/pre-pr.md` to `home.file` in `claude-code.nix` so all static Claude Code config is version-controlled and deployed consistently across machines
- Expands `settings.json` permissions to pre-approve common commands (`git`, `gh`, `nix`, `aws`, `curl`, `python`, `uv`, `mise`, `prek`, `tofu`), with `tofu apply` explicitly denied to require confirmation before creating/destroying resources
- Moves the AWS permissions previously in `settings.local.json` into the managed `settings.json`; `~/.claude/settings.local.json` can be deleted after `switch` runs

## Test plan

- [x] Run `home-manager switch --flake .#otto@aarch64-darwin` and verify symlinks appear under `~/.claude/`
- [ ] Confirm `/pre-pr` is available as a slash command in Claude Code
- [x] Delete `~/.claude/settings.local.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)