### PR TITLE
fix: migrate programs.claude-code.memory.source to context

### DIFF
--- a/packages/claude-code.nix
+++ b/packages/claude-code.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.104";
+  version = "2.1.107";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-Cjf7xYaIPR0xrwEG91/HIt0/2sU+t2mXbadzP2VFucU=";
+    hash = "sha256-FpJ7grsXbBJxzbqSZTN6uICd1sGxizMEpHbs1n9yW3s=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/programs/claude-code.nix
+++ b/programs/claude-code.nix
@@ -18,7 +18,7 @@ in
     enable = true;
     package = claudeCode;
 
-    memory.source = ./claude/CLAUDE.md;
+    context = ./claude/CLAUDE.md;
 
     settings = {
       permissions = {


### PR DESCRIPTION
## Summary

- The home-manager `claude-code` module renamed the split `memory.source`/`memory.text` options to a unified `context` option (accepts either a `path` or inline string)
- Updates `programs/claude-code.nix` to use `context = ./claude/CLAUDE.md` instead of the now-deprecated `memory.source`
- Bumps `flake.lock` (home-manager: `e35c39f` → `8a423e4`)

## Test plan

- [ ] Run `switch` after merge to confirm the warning is gone and CLAUDE.md is still linked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)