### PR TITLE
claude update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1776891022,
+        "narHash": "sha256-vEe2f4NEhMvaNDpM1pla4hteaIIGQyAMKUfIBPLasr0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "508daf831ab8d1b143d908239c39a7d8d39561b2",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/packages/claude-code.nix
+++ b/packages/claude-code.nix
@@ -2,48 +2,59 @@
   lib,
   stdenv,
   fetchzip,
-  makeWrapper,
-  nodejs,
+  autoPatchelfHook,
   procps,
   bubblewrap,
   socat,
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "claude-code";
+let
   version = "2.1.117";
 
-  src = fetchzip {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-8dRSs6GCwX1bfpz5tKzk6OhmG0aFfcvQOgv2+VK04gg=";
+  sources = {
+    "aarch64-darwin" = {
+      pkg = "darwin-arm64";
+      hash = "sha256-mpkawSVoKmQKyR52K7M36VIiDIIr9YqbUM7sDD6BjEs=";
+    };
+    "x86_64-linux" = {
+      pkg = "linux-x64";
+      hash = "sha256-XaGBC9WQ2f1bOINC27oK5Xyk/+FuJYixilPfj6eRp8w=";
+    };
+    "aarch64-linux" = {
+      pkg = "linux-arm64";
+      hash = "sha256-bueyoEK4WCiUsLBPj+pclK1ukiWahIhuKV4UA5hxC6w=";
+    };
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  src_info =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "claude-code";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-${src_info.pkg}/-/claude-code-${src_info.pkg}-${version}.tgz";
+    inherit (src_info) hash;
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    procps
+    bubblewrap
+    socat
+  ];
 
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/claude-code $out/bin
-
-    cp cli.js $out/lib/claude-code/
-    substituteInPlace $out/lib/claude-code/cli.js \
-      --replace-fail '#!/bin/sh' '#!/usr/bin/env sh'
-
-    makeWrapper ${nodejs}/bin/node $out/bin/claude \
-      --add-flags "$out/lib/claude-code/cli.js" \
-      --set DISABLE_AUTOUPDATER 1 \
-      --set DISABLE_INSTALLATION_CHECKS 1 \
-      --unset DEV \
-      --prefix PATH : ${
-        lib.makeBinPath (
-          [ procps ]
-          ++ lib.optionals stdenv.hostPlatform.isLinux [
-            bubblewrap
-            socat
-          ]
-        )
-      }
+    mkdir -p $out/bin
+    cp package/claude $out/bin/claude
+    chmod +x $out/bin/claude
 
     runHook postInstall
   '';
@@ -53,6 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/anthropics/claude-code";
     license = lib.licenses.unfree;
     mainProgram = "claude";
-    platforms = lib.platforms.unix;
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
   };
-})
+}

--- a/packages/claude-code.nix
+++ b/packages/claude-code.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.110";
+  version = "2.1.117";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-lotQBnIXHrp/KaXl4c2xPnEaj/CZG+f2ZpcPkAroomQ=";
+    hash = "sha256-8dRSs6GCwX1bfpz5tKzk6OhmG0aFfcvQOgv2+VK04gg=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/packages/claude-code.nix
+++ b/packages/claude-code.nix
@@ -13,7 +13,7 @@ let
   sources = {
     "aarch64-darwin" = {
       pkg = "darwin-arm64";
-      hash = "sha256-mpkawSVoKmQKyR52K7M36VIiDIIr9YqbUM7sDD6BjEs=";
+      hash = "sha256-MHGn2ZRUAIX6N8hzRZ95nCmNAQ9BwBGEqkEn3oylBWQ=";
     };
     "x86_64-linux" = {
       pkg = "linux-x64";
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code-${src_info.pkg}/-/claude-code-${src_info.pkg}-${version}.tgz";
     inherit (src_info) hash;
-    stripRoot = false;
   };
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
@@ -53,7 +52,7 @@ stdenv.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/bin
-    cp package/claude $out/bin/claude
+    cp claude $out/bin/claude
     chmod +x $out/bin/claude
 
     runHook postInstall

--- a/programs/claude-code.nix
+++ b/programs/claude-code.nix
@@ -5,8 +5,7 @@ let
     inherit (pkgs)
       stdenv
       fetchzip
-      makeWrapper
-      nodejs
+      autoPatchelfHook
       procps
       bubblewrap
       socat


### PR DESCRIPTION
## Summary

- Bumps Claude Code to 2.1.117
- Rewrites the Nix derivation to match the new upstream distribution: 2.1.117 dropped the bundled `cli.js` in favour of platform-specific native binaries shipped as separate optional npm packages (`@anthropic-ai/claude-code-darwin-arm64`, `-linux-x64`, `-linux-arm64`)
- Removes Node/`makeWrapper` plumbing; installs the native binary directly
- Adds `autoPatchelfHook` for Linux ELF patching

## Test plan

- [x] `nix build .#homeConfigurations."otto@aarch64-darwin".activationPackage` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)