### PR TITLE
Add ~/.local/bin to sessionPath

### DIFF
--- a/programs/shell.nix
+++ b/programs/shell.nix
@@ -98,6 +98,8 @@ let
   };
 in
 {
+  home.sessionPath = [ "$HOME/.local/bin" ];
+
   home.packages = [
     pkgs.coreutils
     gst


### PR DESCRIPTION
## Summary

- Adds `$HOME/.local/bin` to `home.sessionPath` in `programs/shell.nix`

## Test plan

- [ ] Run `switch` after merging and verify `~/.local/bin` is in `$PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)